### PR TITLE
German version of utf-8-set-source-and-executable-character-sets-to-u…

### DIFF
--- a/docs/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8.md
+++ b/docs/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8.md
@@ -1,5 +1,5 @@
 ---
-title: /UTF-8 (Quelle festlegen und ausführbare Zeichensätze auf UTF-8)
+title: /UTF-8 (Quell- und Ausführungszeichensätze auf UTF-8 festlegen)
 ms.date: 11/04/2016
 f1_keywords:
 - /utf-8
@@ -13,9 +13,9 @@ ms.contentlocale: de-DE
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "62317288"
 ---
-# <a name="utf-8-set-source-and-executable-character-sets-to-utf-8"></a>/UTF-8 (Quelle festlegen und ausführbare Zeichensätze auf UTF-8)
+# <a name="utf-8-set-source-and-executable-character-sets-to-utf-8"></a>/UTF-8 (Quell- und Ausführungszeichensätze auf UTF-8 festlegen)
 
-Gibt an, sowohl der quellzeichensatz der ausführungszeichensatz als UTF-8.
+Legt sowohl den Quell- als auch den Ausführungszeichensatz auf UTF-8 fest.
 
 ## <a name="syntax"></a>Syntax
 
@@ -25,17 +25,17 @@ Gibt an, sowohl der quellzeichensatz der ausführungszeichensatz als UTF-8.
 
 ## <a name="remarks"></a>Hinweise
 
-Sie können die **/utf-8** verwenden, um anzugeben, sowohl die Quell-und legt fest, wie mithilfe von UTF-8 codiert. Dies ist äquivalent zum Angeben von **/source-Charset:utf-8 /execution-Charset:utf-8** in der Befehlszeile. Diese Optionen auch ermöglicht die **/Validate-CharSet** standardmäßig die Option. Eine Liste der unterstützten Codepage-IDs und Namen der Zeichensatz, finden Sie unter [Codepage-IDs](/windows/desktop/Intl/code-page-identifiers).
+Sie können **/utf-8** verwenden, um festzulegen, dass Quell- und Ausführungszeichensatz mittels UTF-8 codiert sind. Diese Option ist äquivalent zu **/source-Charset:utf-8** und **/execution-Charset:utf-8** in der Befehlszeile. Jede dieser Optionen aktiviert automatisch auch **/Validate-CharSet**. Eine Liste der unterstützten Codepage-Identifiers und Zeichensätze finden Sie unter [Codepage-IDs](/windows/desktop/Intl/code-page-identifiers).
 
-Standardmäßig erkennt Visual Studio eine Bytereihenfolge-Marke, um festzustellen, ob die Quelldatei in eine codierte Unicode-Format, z. B. UTF-16 oder UTF-8 ist. Wenn keine Bytereihenfolge-Marke befindet, es geht davon aus die Quelldatei codiert mithilfe der aktuellen Codepage für Benutzer, es sei denn, Sie mithilfe eine Codepage angegeben haben **/utf-8** oder **/Source-CharSet** Option. Visual Studio können Sie C++-Quellcode mithilfe der verschiedenen zeichencodierungen zu speichern. Weitere Informationen zu Quell- und ausführungszeichensätze, finden Sie unter [Zeichensätze](../../cpp/character-sets.md) in der Dokumentation zur Sprache.
+Standardmäßig sucht Visual Studio nach einer Byte-Order-Markierung, um festzustellen, ob die Quelldatei in einem Unicode-Format kodiert ist, z. B. UTF-16 oder UTF-8. Wenn keine Byte-Order-Markierung gefunden wurde, geht das Programm davon aus, dass die Quelldatei mithilfe der aktuellen Codepage des Benutzers kodiert wurde, es sei denn, Sie haben mittels **/utf-8** oder **/Source-CharSet** eine Codepage spezifiziert. Visual Studio erlaubt es Ihnen Ihren C++-Quellcode mithilfe  verschiedener Zeichenkodierungen zu speichern. Weitere Informationen zu Quell- und Ausführungszeichensätzen finden Sie unter [Zeichensätze](../../cpp/character-sets.md) in der Sprachdokumentation.
 
 ### <a name="to-set-this-compiler-option-in-the-visual-studio-development-environment"></a>So legen Sie diese Compileroption in der Visual Studio-Entwicklungsumgebung fest
 
-1. Öffnen Sie das Dialogfeld **Eigenschaftenseiten** des Projekts. Weitere Informationen finden Sie unter [Festlegen von C++-Compiler und die Build-Eigenschaften in Visual Studio](../working-with-project-properties.md).
+1. Öffnen Sie das Dialogfeld **Eigenschaftenseiten** des Projektes. Weitere Informationen finden Sie unter [Festlegen von C++-Compiler und die Build-Eigenschaften in Visual Studio](../working-with-project-properties.md).
 
 1. Erweitern Sie die **Konfigurationseigenschaften**, **C/C++-**, **Befehlszeile** Ordner.
 
-1. In **zusätzliche Optionen**, Hinzufügen der **/utf-8** verwenden, um die bevorzugte Codierung anzugeben.
+1. In **Zusätzliche Optionen**, den Eintrag "**/utf-8**" hinzufügen, um UTF-8 als bevorzugte Kodierung anzugeben.
 
 1. Klicken Sie auf **OK**, um die Änderungen zu speichern.
 

--- a/docs/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8.md
+++ b/docs/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8.md
@@ -1,5 +1,5 @@
 ---
-title: /UTF-8 (Quell- und Ausführungszeichensätze auf UTF-8 festlegen)
+title: /UTF-8 (Festlegen von Quell- und Ausführungszeichensätze auf UTF-8)
 ms.date: 11/04/2016
 f1_keywords:
 - /utf-8
@@ -13,9 +13,9 @@ ms.contentlocale: de-DE
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "62317288"
 ---
-# <a name="utf-8-set-source-and-executable-character-sets-to-utf-8"></a>/UTF-8 (Quell- und Ausführungszeichensätze auf UTF-8 festlegen)
+# <a name="utf-8-set-source-and-executable-character-sets-to-utf-8"></a>/UTF-8 (Festlegen der Quell- und Ausführungszeichensätze auf UTF-8)
 
-Legt sowohl den Quell- als auch den Ausführungszeichensatz auf UTF-8 fest.
+Gibt sowohl den Quell- als auch den Ausführungszeichensatz als UTF-8 an.
 
 ## <a name="syntax"></a>Syntax
 
@@ -25,17 +25,17 @@ Legt sowohl den Quell- als auch den Ausführungszeichensatz auf UTF-8 fest.
 
 ## <a name="remarks"></a>Hinweise
 
-Sie können **/utf-8** verwenden, um festzulegen, dass Quell- und Ausführungszeichensatz mittels UTF-8 codiert sind. Diese Option ist äquivalent zu **/source-Charset:utf-8** und **/execution-Charset:utf-8** in der Befehlszeile. Jede dieser Optionen aktiviert automatisch auch **/Validate-CharSet**. Eine Liste der unterstützten Codepage-Identifiers und Zeichensätze finden Sie unter [Codepage-IDs](/windows/desktop/Intl/code-page-identifiers).
+Sie können **/utf-8** verwenden, um festzulegen, dass sowohl der Quell- als auch der Ausführungszeichensatz mittels UTF-8 codiert ist. Diese Option ist äquivalent zu **/source-Charset:utf-8** und **/execution-Charset:utf-8** in der Befehlszeile. Jede dieser Optionen aktiviert automatisch auch **/Validate-CharSet**. Eine Liste der unterstützten Codepagebezeichner und Zeichensätze finden Sie unter [Code Page Identifiers (Codepagebezeichner)](/windows/desktop/Intl/code-page-identifiers).
 
-Standardmäßig sucht Visual Studio nach einer Byte-Order-Markierung, um festzustellen, ob die Quelldatei in einem Unicode-Format kodiert ist, z. B. UTF-16 oder UTF-8. Wenn keine Byte-Order-Markierung gefunden wurde, geht das Programm davon aus, dass die Quelldatei mithilfe der aktuellen Codepage des Benutzers kodiert wurde, es sei denn, Sie haben mittels **/utf-8** oder **/Source-CharSet** eine Codepage spezifiziert. Visual Studio erlaubt es Ihnen Ihren C++-Quellcode mithilfe  verschiedener Zeichenkodierungen zu speichern. Weitere Informationen zu Quell- und Ausführungszeichensätzen finden Sie unter [Zeichensätze](../../cpp/character-sets.md) in der Sprachdokumentation.
+Standardmäßig sucht Visual Studio nach einer Bytereihenfolge-Marke, um festzustellen, ob die Quelldatei in einem Unicode-Format codiert ist, z. B. UTF-16 oder UTF-8. Wenn keine Bytereihenfolge-Marke gefunden wurde, geht das Programm davon aus, dass die Quelldatei mithilfe der aktuellen Codepage des Benutzers codiert wurde, es sei denn, Sie haben mittels **/utf-8** oder **/Source-CharSet** eine Codepage spezifiziert. Visual Studio lässt zu, dass Sie Ihren C++-Quellcode mithilfe verschiedener Zeichencodierungen speichern. Weitere Informationen zu Quell- und Ausführungszeichensätzen finden Sie unter [Zeichensätze](../../cpp/character-sets.md) in der Sprachdokumentation.
 
 ### <a name="to-set-this-compiler-option-in-the-visual-studio-development-environment"></a>So legen Sie diese Compileroption in der Visual Studio-Entwicklungsumgebung fest
 
-1. Öffnen Sie das Dialogfeld **Eigenschaftenseiten** des Projektes. Weitere Informationen finden Sie unter [Festlegen von C++-Compiler und die Build-Eigenschaften in Visual Studio](../working-with-project-properties.md).
+1. Öffnen Sie das Dialogfeld **Eigenschaftenseiten** des Projekts. Weitere Informationen finden Sie unter [Festlegen des Compilers und der Buildeigenschaften](../working-with-project-properties.md).
 
 1. Erweitern Sie die **Konfigurationseigenschaften**, **C/C++-**, **Befehlszeile** Ordner.
 
-1. In **Zusätzliche Optionen**, den Eintrag "**/utf-8**" hinzufügen, um UTF-8 als bevorzugte Kodierung anzugeben.
+1. Fügen Sie unter **Zusätzliche Optionen** den Eintrag "**/utf-8**" hinzu, um UTF-8 als bevorzugte Codierung anzugeben.
 
 1. Klicken Sie auf **OK**, um die Änderungen zu speichern.
 


### PR DESCRIPTION
…tf-8.md

The automatic translation from english to german is lacking and in many cases hard to comprehend. My translation form the english source page still could do with proofreading from an experienced german programmer, as I'm unsure about the usage of certain anglizisms in the german-speaking programming world.