### PR TITLE
Change "Arbeitsauslastungen" to "Workloads"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ ms.locfileid: "70177503"
                                     </div>
                                 </div>
                                 <div class="cardText">
-                                    <h3>Installieren von Visual Studio und Wählen der C++-Arbeitsauslastungen</h3>
+                                    <h3>Installieren von Visual Studio und Wählen der C++-Workloads</h3>
                                 </div>
                             </div>
                         </div>
@@ -75,10 +75,10 @@ ms.locfileid: "70177503"
         <h1>Visual C++–Dokumentation</h1>
         <ul class="pivots">
             <li>
-                <a href="#workloads">Arbeitsauslastungen</a>
+                <a href="#workloads">Workloads</a>
                 <ul id="workloads">
                     <li>
-                        <a href="#workloads1">Arbeitsauslastungen</a>
+                        <a href="#workloads1">Workloads</a>
                         <ul id="workloads1" class="cardsC">
                             <li>
                                 <a href="/cpp/cppcx/universal-windows-apps-cpp">


### PR DESCRIPTION
Change the word "Arbeitsauslastungen" to "Workloads", as there is no suitable German translation for "workloads".
